### PR TITLE
Add Location of keyboard to support multiple external ones

### DIFF
--- a/autokbisw/IOKeyEventMonitor.swift
+++ b/autokbisw/IOKeyEventMonitor.swift
@@ -96,7 +96,8 @@ class IOKeyEventMonitor {
       let vendorId = String(describing: IOHIDDeviceGetProperty(senderDevice, kIOHIDVendorIDKey as CFString));
       let productId = String(describing: IOHIDDeviceGetProperty(senderDevice, kIOHIDProductIDKey as CFString));
       let product = String(describing: IOHIDDeviceGetProperty(senderDevice, kIOHIDProductKey as CFString));
-      let keyboard = "\(product)[\(vendorId)-\(productId)]";
+      let locationID = String(describing: IOHIDDeviceGetProperty(senderDevice, kIOHIDLocationIDKey as CFString));
+      let keyboard = "\(product)[\(vendorId)-\(productId)-\(locationID)]";
       selfPtr.onKeyboardEvent(keyboard: keyboard);
 
     }


### PR DESCRIPTION
Great app.

This PR should allow multiple external keyboards as it uses the Location of the Keyboard in addition as identifier and should fix #6.

