### PR TITLE
Swiftify code

### DIFF
--- a/autokbisw/IOKeyEventMonitor.swift
+++ b/autokbisw/IOKeyEventMonitor.swift
@@ -26,21 +26,11 @@ class IOKeyEventMonitor {
   var lastActiveKeyboard: String = ""
   var kb2is: [String: TISInputSource] = [String: TISInputSource]()
 
-
-  private class func createDeviceMatchingDictionary( usagePage: Int, usage: Int) -> CFMutableDictionary {
-    let dict = [
-      kIOHIDDeviceUsageKey: usage,
-      kIOHIDDeviceUsagePageKey: usagePage
-    ] as NSDictionary
-
-    return dict.mutableCopy() as! NSMutableDictionary;
-  }
-
   init? ( usagePage: Int, usage: Int) {
     hidManager = IOHIDManagerCreate( kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone));
     notificationCenter = CFNotificationCenterGetDistributedCenter();
-    let match: CFMutableDictionary = IOKeyEventMonitor.createDeviceMatchingDictionary(usagePage: usagePage, usage: usage);
-    IOHIDManagerSetDeviceMatching( hidManager, match);
+    let deviceMatch: CFMutableDictionary = [kIOHIDDeviceUsageKey: usage, kIOHIDDeviceUsagePageKey: usagePage] as NSMutableDictionary
+    IOHIDManagerSetDeviceMatching( hidManager, deviceMatch);
   }
 
   deinit {

--- a/autokbisw/IOKeyEventMonitor.swift
+++ b/autokbisw/IOKeyEventMonitor.swift
@@ -18,13 +18,12 @@ import IOKit
 import IOKit.usb
 import IOKit.hid
 
-class IOKeyEventMonitor {
-  private
-  let hidManager: IOHIDManager
-  let notificationCenter: CFNotificationCenter
+final internal class IOKeyEventMonitor {
+  private let hidManager: IOHIDManager
+  private let notificationCenter: CFNotificationCenter
 
-  var lastActiveKeyboard: String = ""
-  var kb2is: [String: TISInputSource] = [String: TISInputSource]()
+  fileprivate var lastActiveKeyboard: String = ""
+  fileprivate var kb2is: [String: TISInputSource] = [String: TISInputSource]()
 
   init? ( usagePage: Int, usage: Int) {
     hidManager = IOHIDManagerCreate( kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone));

--- a/autokbisw/IOKeyEventMonitor.swift
+++ b/autokbisw/IOKeyEventMonitor.swift
@@ -39,33 +39,6 @@ final internal class IOKeyEventMonitor {
     CFNotificationCenterRemoveObserver(notificationCenter, context, CFNotificationName(kTISNotifySelectedKeyboardInputSourceChanged), nil);
   }
 
-  func restoreInputSource(keyboard: String) -> Void {
-    if let targetIs = kb2is[keyboard] {
-      //print("set input source to \(targetIs) for keyboard \(keyboard)");
-      TISSelectInputSource(targetIs)
-    } else {
-      self.storeInputSource(keyboard: keyboard);
-    }
-  }
-
-  func storeInputSource(keyboard: String) -> Void {
-    let currentSource: TISInputSource = TISCopyCurrentKeyboardInputSource().takeUnretainedValue();
-    kb2is[keyboard] = currentSource;
-  }
-
-  func onInputSourceChanged() -> Void {
-    self.storeInputSource(keyboard: self.lastActiveKeyboard);
-  }
-
-  func onKeyboardEvent(keyboard: String) -> Void {
-    if(self.lastActiveKeyboard != keyboard) {
-      //print("Active keyboard changed from \(self.lastActiveKeyboard) to \(keyboard)");
-      self.restoreInputSource(keyboard: keyboard);
-      self.lastActiveKeyboard = keyboard;
-    }
-  }
-
-
   func start() -> Void {
     let context = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque());
     let myHIDKeyboardCallback: IOHIDValueCallback = {
@@ -97,4 +70,32 @@ final internal class IOKeyEventMonitor {
     IOHIDManagerOpen( hidManager, IOOptionBits(kIOHIDOptionsTypeNone));
   }
 
+}
+
+extension IOKeyEventMonitor {
+  func restoreInputSource(keyboard: String) -> Void {
+    if let targetIs = kb2is[keyboard] {
+      //print("set input source to \(targetIs) for keyboard \(keyboard)");
+      TISSelectInputSource(targetIs)
+    } else {
+      self.storeInputSource(keyboard: keyboard);
+    }
+  }
+  
+  func storeInputSource(keyboard: String) -> Void {
+    let currentSource: TISInputSource = TISCopyCurrentKeyboardInputSource().takeUnretainedValue();
+    kb2is[keyboard] = currentSource;
+  }
+  
+  func onInputSourceChanged() -> Void {
+    self.storeInputSource(keyboard: self.lastActiveKeyboard);
+  }
+  
+  func onKeyboardEvent(keyboard: String) -> Void {
+    if(self.lastActiveKeyboard != keyboard) {
+      //print("Active keyboard changed from \(self.lastActiveKeyboard) to \(keyboard)");
+      self.restoreInputSource(keyboard: keyboard);
+      self.lastActiveKeyboard = keyboard;
+    }
+  }
 }

--- a/autokbisw/IOKeyEventMonitor.swift
+++ b/autokbisw/IOKeyEventMonitor.swift
@@ -18,14 +18,6 @@ import IOKit
 import IOKit.usb
 import IOKit.hid
 
-
-struct IOKeyEventMonitorContext {
-  var lastSeenSender: String
-  init(lastSeenSender: String) {
-    self.lastSeenSender = lastSeenSender
-  }
-}
-
 class IOKeyEventMonitor {
   private
   let hidManager: IOHIDManager

--- a/autokbisw/IOKeyEventMonitor.swift
+++ b/autokbisw/IOKeyEventMonitor.swift
@@ -92,10 +92,9 @@ extension IOKeyEventMonitor {
   }
   
   func onKeyboardEvent(keyboard: String) -> Void {
-    if(self.lastActiveKeyboard != keyboard) {
-      //print("Active keyboard changed from \(self.lastActiveKeyboard) to \(keyboard)");
-      self.restoreInputSource(keyboard: keyboard);
-      self.lastActiveKeyboard = keyboard;
-    }
+    guard self.lastActiveKeyboard != keyboard else { return }
+      
+    self.restoreInputSource(keyboard: keyboard);
+    self.lastActiveKeyboard = keyboard;
   }
 }

--- a/autokbisw/IOKeyEventMonitor.swift
+++ b/autokbisw/IOKeyEventMonitor.swift
@@ -22,7 +22,6 @@ class IOKeyEventMonitor {
   private
   let hidManager: IOHIDManager
   let notificationCenter: CFNotificationCenter
-  let match: CFMutableDictionary
 
   var lastActiveKeyboard: String = ""
   var kb2is: [String: TISInputSource] = [String: TISInputSource]()
@@ -40,7 +39,7 @@ class IOKeyEventMonitor {
   init? ( usagePage: Int, usage: Int) {
     hidManager = IOHIDManagerCreate( kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone));
     notificationCenter = CFNotificationCenterGetDistributedCenter();
-    match = IOKeyEventMonitor.createDeviceMatchingDictionary(usagePage: usagePage, usage: usage);
+    let match: CFMutableDictionary = IOKeyEventMonitor.createDeviceMatchingDictionary(usagePage: usagePage, usage: usage);
     IOHIDManagerSetDeviceMatching( hidManager, match);
   }
 


### PR DESCRIPTION
closes #4

These changes are based on studying @dehesa's pull request.
However it splits the changes in atomic commits and rejects some changes: 
- doesn't change project file
- doesn't add .gitignore file
- doesn't rename the class and its file
- doesn't use guard in restoreInputSource
it also adds a couple more changes: 
- extracts observeIputSourceChangedNotification from start
- extracts registerHIDKeyboardCallback from start 

These last two changes are foundation work for introducing a non daemon mode which will let users list HID devices (if I can figure it out :) )
I also intend to enable a debug mode further on