### PR TITLE
Feat/location based keyboard identifiers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "autokbisw/CommandLineKit"]
+	path = autokbisw/CommandLineKit
+	url = git@github.com:jatoben/CommandLine.git

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ launchctl load ~/Library/LaunchAgents/eu.byjean.autokbisw.plist
 
 ### From Source
 
-Clone this repository, make sure you have xcode installed and run the following
-command :
+Clone this repository (using --recursive to init the CommandLineKit submodule), 
+then make sure you have xcode installed and run the following command :
 ```
 xcodebuild -scheme autokbis build
 ```

--- a/autokbisw.xcodeproj/project.pbxproj
+++ b/autokbisw.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		0F2C43CC1DE4B6A20076D74F /* autokbisw in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0F81A5041DE48BA7007372C9 /* autokbisw */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		0F80A1E91F9E4EEF0012D75D /* UserOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F80A1E81F9E4EEF0012D75D /* UserOptions.swift */; };
+		0F80A21B1F9E7F060012D75D /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F80A2181F9E7F050012D75D /* Option.swift */; };
+		0F80A21C1F9E7F060012D75D /* CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F80A2191F9E7F050012D75D /* CommandLine.swift */; };
+		0F80A21D1F9E7F060012D75D /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F80A21A1F9E7F050012D75D /* StringExtensions.swift */; };
 		0F81A5141DE48C7A007372C9 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F81A5131DE48C7A007372C9 /* IOKit.framework */; };
 		0FB8D5BC1DE6F3B9006EA5A5 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F81A5151DE48CDB007372C9 /* main.swift */; };
 		0FB8D5BD1DE6F3B9006EA5A5 /* IOKeyEventMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2C43CF1DE5CC440076D74F /* IOKeyEventMonitor.swift */; };
@@ -29,6 +33,10 @@
 /* Begin PBXFileReference section */
 		0F2C43CE1DE4B7DA0076D74F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0F2C43CF1DE5CC440076D74F /* IOKeyEventMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IOKeyEventMonitor.swift; sourceTree = "<group>"; };
+		0F80A1E81F9E4EEF0012D75D /* UserOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserOptions.swift; sourceTree = "<group>"; };
+		0F80A2181F9E7F050012D75D /* Option.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Option.swift; sourceTree = "<group>"; };
+		0F80A2191F9E7F050012D75D /* CommandLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandLine.swift; sourceTree = "<group>"; };
+		0F80A21A1F9E7F050012D75D /* StringExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
 		0F81A5041DE48BA7007372C9 /* autokbisw */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = autokbisw; sourceTree = BUILT_PRODUCTS_DIR; };
 		0F81A50F1DE48C2F007372C9 /* autokbisw-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "autokbisw-Bridging-Header.h"; sourceTree = "<group>"; };
 		0F81A5131DE48C7A007372C9 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
@@ -47,6 +55,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0F80A20A1F9E7DD90012D75D /* CommandLineKit */ = {
+			isa = PBXGroup;
+			children = (
+				0F80A2191F9E7F050012D75D /* CommandLine.swift */,
+				0F80A2181F9E7F050012D75D /* Option.swift */,
+				0F80A21A1F9E7F050012D75D /* StringExtensions.swift */,
+			);
+			name = CommandLineKit;
+			path = CommandLineKit/CommandLineKit;
+			sourceTree = "<group>";
+		};
 		0F81A4FB1DE48BA6007372C9 = {
 			isa = PBXGroup;
 			children = (
@@ -68,6 +87,8 @@
 		0F81A5061DE48BA7007372C9 /* autokbisw */ = {
 			isa = PBXGroup;
 			children = (
+				0F80A20A1F9E7DD90012D75D /* CommandLineKit */,
+				0F80A1E81F9E4EEF0012D75D /* UserOptions.swift */,
 				0F81A50F1DE48C2F007372C9 /* autokbisw-Bridging-Header.h */,
 				0F81A5151DE48CDB007372C9 /* main.swift */,
 				0F2C43CE1DE4B7DA0076D74F /* Info.plist */,
@@ -144,8 +165,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0FB8D5BC1DE6F3B9006EA5A5 /* main.swift in Sources */,
+				0F80A21D1F9E7F060012D75D /* StringExtensions.swift in Sources */,
+				0F80A21C1F9E7F060012D75D /* CommandLine.swift in Sources */,
+				0F80A21B1F9E7F060012D75D /* Option.swift in Sources */,
+				0F80A1E91F9E4EEF0012D75D /* UserOptions.swift in Sources */,
 				0FB8D5BD1DE6F3B9006EA5A5 /* IOKeyEventMonitor.swift in Sources */,
+				0FB8D5BC1DE6F3B9006EA5A5 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/autokbisw/IOKeyEventMonitor.swift
+++ b/autokbisw/IOKeyEventMonitor.swift
@@ -80,13 +80,15 @@ final internal class IOKeyEventMonitor {
       let locationId = String(describing: IOHIDDeviceGetProperty(senderDevice, kIOHIDLocationIDKey as CFString));
       let uniqueId = String(describing: IOHIDDeviceGetProperty(senderDevice, kIOHIDUniqueIDKey as CFString));
       
-      let keyboard = "\(product) - [\(vendorId)-\(productId)-\(manufacturer)-\(serialNumber)]";
+      let keyboard =
+      selfPtr.userOptions.useLocation ?
+      "\(product)-[\(vendorId)-\(productId)-\(manufacturer)-\(serialNumber)-\(locationId)]" :
+      "\(product)-[\(vendorId)-\(productId)-\(manufacturer)-\(serialNumber)]";
       
       if(selfPtr.userOptions.verbosity >= UserOptions.TRACE){
          print("received event from keyboard \(keyboard) - \(locationId) -  \(uniqueId)");
       }
-      selfPtr.onKeyboardEvent(keyboard: keyboard);
-      
+      selfPtr.onKeyboardEvent(keyboard: keyboard);    
     }
     
     IOHIDManagerRegisterInputValueCallback( hidManager, myHIDKeyboardCallback, context);

--- a/autokbisw/IOKeyEventMonitor.swift
+++ b/autokbisw/IOKeyEventMonitor.swift
@@ -75,7 +75,16 @@ final internal class IOKeyEventMonitor {
       let vendorId = String(describing: IOHIDDeviceGetProperty(senderDevice, kIOHIDVendorIDKey as CFString));
       let productId = String(describing: IOHIDDeviceGetProperty(senderDevice, kIOHIDProductIDKey as CFString));
       let product = String(describing: IOHIDDeviceGetProperty(senderDevice, kIOHIDProductKey as CFString));
-      let keyboard = "\(product)[\(vendorId)-\(productId)]";
+      let manufacturer = String(describing: IOHIDDeviceGetProperty(senderDevice, kIOHIDManufacturerKey as CFString));
+      let serialNumber = String(describing: IOHIDDeviceGetProperty(senderDevice, kIOHIDSerialNumberKey as CFString));
+      let locationId = String(describing: IOHIDDeviceGetProperty(senderDevice, kIOHIDLocationIDKey as CFString));
+      let uniqueId = String(describing: IOHIDDeviceGetProperty(senderDevice, kIOHIDUniqueIDKey as CFString));
+      
+      let keyboard = "\(product) - [\(vendorId)-\(productId)-\(manufacturer)-\(serialNumber)]";
+      
+      if(selfPtr.userOptions.verbosity >= UserOptions.TRACE){
+         print("received event from keyboard \(keyboard) - \(locationId) -  \(uniqueId)");
+      }
       selfPtr.onKeyboardEvent(keyboard: keyboard);
       
     }
@@ -91,7 +100,9 @@ extension IOKeyEventMonitor {
   
   func restoreInputSource(keyboard: String) -> Void {
     if let targetIs = kb2is[keyboard] {
-      //print("set input source to \(targetIs) for keyboard \(keyboard)");
+      if(userOptions.verbosity >= UserOptions.DEBUG){
+        print("set input source to \(targetIs) for keyboard \(keyboard)");
+      }
       TISSelectInputSource(targetIs)
     } else {
       self.storeInputSource(keyboard: keyboard);

--- a/autokbisw/IOKeyEventMonitor.swift
+++ b/autokbisw/IOKeyEventMonitor.swift
@@ -22,14 +22,17 @@ final internal class IOKeyEventMonitor {
   private let hidManager: IOHIDManager
   
   fileprivate let notificationCenter: CFNotificationCenter
+  fileprivate let userOptions: UserOptions
   fileprivate var lastActiveKeyboard: String = ""
   fileprivate var kb2is: [String: TISInputSource] = [String: TISInputSource]()
 
-  init? ( usagePage: Int, usage: Int) {
+  init? ( usagePage: Int, usage: Int, _userOptions: UserOptions) {
+    userOptions = _userOptions;
     hidManager = IOHIDManagerCreate( kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone));
     notificationCenter = CFNotificationCenterGetDistributedCenter();
     let deviceMatch: CFMutableDictionary = [kIOHIDDeviceUsageKey: usage, kIOHIDDeviceUsagePageKey: usagePage] as NSMutableDictionary
     IOHIDManagerSetDeviceMatching( hidManager, deviceMatch);
+
   }
 
   deinit {

--- a/autokbisw/UserOptions.swift
+++ b/autokbisw/UserOptions.swift
@@ -1,0 +1,35 @@
+//Copyright [2017] Jean Helou
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+import Foundation
+
+
+internal struct UserOptions {
+  static let useLocation = BoolOption(shortFlag: "l",
+                                      longFlag: "location",
+                                      helpMessage: "Uses locationId to identify keyboards (defaults to false).\n\n" +
+                                                   "Note that the locationId changes when you plug a keyboard in a different port." +
+                                                   "Therefore using the locationId in the keyboards identifiers means the " +
+                                                   "configured language will be associated to a keyboard on a specific port.")
+  static let help = BoolOption(shortFlag: "h", longFlag: "help",
+                        helpMessage: "Prints this help message.")
+  static let verbosity = CounterOption(shortFlag: "v", longFlag: "verbose",
+                                helpMessage: "Print verbose messages. Specify multiple times to increase verbosity.")
+  
+  static let DEBUG: Int=1
+  static let TRACE: Int=2
+  
+  let useLocation: Bool
+  let verbosity: Int
+}

--- a/autokbisw/main.swift
+++ b/autokbisw/main.swift
@@ -16,7 +16,25 @@
 import Foundation
 
 
-let monitor = IOKeyEventMonitor(usagePage: 0x01, usage: 6);
-monitor?.start();
-CFRunLoopRun()
+let cli = CommandLine()
 
+cli.addOptions(UserOptions.useLocation, UserOptions.verbosity, UserOptions.help)
+
+do {
+  try cli.parse()
+} catch {
+  cli.printUsage(error)
+  exit(EX_USAGE)
+}
+
+if(UserOptions.help.value){
+  cli.printUsage()
+}else{
+  if(UserOptions.verbosity.value > 0){
+    print("starting with useLocation:\(UserOptions.useLocation.value) - verbosity:\(UserOptions.verbosity.value)");
+  }
+  let userOptions = UserOptions(useLocation: UserOptions.useLocation.value,verbosity: UserOptions.verbosity.value)
+  let monitor = IOKeyEventMonitor(usagePage: 0x01, usage: 6, _userOptions: userOptions);
+  monitor?.start();
+  CFRunLoopRun()
+}


### PR DESCRIPTION
Includes locationId in the keyboards identifiers (defaults to false)

Note that the locationId changes when you plug a keyboard in a different port.
Therefore using the locationId in the keyboards identifiers means the 
configured language will be associated to a keyboard on a specific port.

Since this branch includes command line parameter parsing, the -v flag was also
added which controls the program's verbosity. use
 * `-v` for debug 
 * `-v -v` for trace
